### PR TITLE
Feat: 메인페이지 정렬 및 북마크 리스트 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,22 @@
 import { useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { styled } from 'styled-components';
 
 import './App.css';
 import MainPage from './pages/MainPage';
 import Footer from './pages/Footer';
 import Header from './pages/Header';
+
+const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  main {
+    width: 1128px;
+    margin: 24px 76px 0;
+  }
+`;
 
 function App() {
   const [ bookmarks, setBookmarks ] = useState(
@@ -14,9 +26,11 @@ function App() {
   return (
     <>
       <Header />
-      <Routes>
-        <Route path='/' element={<MainPage bookmarks={bookmarks} setBookmarks={setBookmarks} />} />
-      </Routes>
+      <Wrapper>
+        <Routes>
+          <Route path='/' element={<MainPage bookmarks={bookmarks} setBookmarks={setBookmarks} />} />
+        </Routes>
+      </Wrapper>
       <Footer />
     </>
   );

--- a/src/components/ItemCard.js
+++ b/src/components/ItemCard.js
@@ -8,8 +8,12 @@ import { itemCardTypes } from '../constants/itemCardTypes';
 const Container = styled.div`
   display: flex;
   flex-direction: column;
-  width: 260px;
-  height: 210px;
+  width: 264px;
+  height: 264px;
+
+  &:not(:nth-child(4n+0)) {
+    margin-right: 24px;
+  }
 `;
 
 const Wrapper = styled.div`
@@ -19,7 +23,7 @@ const Wrapper = styled.div`
 
 const ImgWrapper = styled.div`
   width: 100%;
-  height: 100%;
+  height: 210px;
   position: relative;
 `;
 
@@ -69,7 +73,7 @@ export default function ItemCard ({ data, bookmarks, setBookmarks }) {
   return (
     <Container>
       <ImgWrapper>
-      <ProductImage src={data['image_url']} />
+        <ProductImage src={data['image_url']} />
         <Star selected={isBookmarked ? true : false} onClick={handleBookmark} />
       </ImgWrapper>
       <Wrapper>
@@ -81,13 +85,13 @@ export default function ItemCard ({ data, bookmarks, setBookmarks }) {
         {data.type === brand && <Title>관심고객수</Title>}
       </Wrapper>
       {data.type === product && (
-        <Wrapper justify-content={'end'}>{data.price}원</Wrapper>
+        <Wrapper justify-content={'end'}>{data.price.toLocaleString('ko-KR')}원</Wrapper>
       )}
       {data.type === exhibition && (
         <Wrapper justify-content={'start'}>{data['sub_title']}</Wrapper>
       )}
       {data.type === brand && (
-        <Wrapper justify-content={'end'}>{data.follower}</Wrapper>
+        <Wrapper justify-content={'end'}>{data.follower.toLocaleString('ko-KR')}</Wrapper>
       )}
     </Container>
   );

--- a/src/components/ItemCardList.js
+++ b/src/components/ItemCardList.js
@@ -1,12 +1,38 @@
 import React from 'react';
-import ItemCard from '../components/ItemCard';
-import { productsData } from '../assets/dummy';
+import { styled } from 'styled-components';
 
-export default function ItemCardList ({ count, bookmarks, setBookmarks }) {
+import { productsData } from '../assets/dummy';
+import { itemCardTypes } from '../constants/itemCardTypes';
+
+import ItemCard from '../components/ItemCard';
+
+const { all, bookmark } = itemCardTypes;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  margin: 12px 0;
+`;
+
+export default function ItemCardList ({ count, bookmarks, setBookmarks, searchType = all }) {
+  const searchData = (type) => {
+    if (type === all) return productsData;
+
+    if (type === bookmark) {
+      return bookmarks.map((id) => productsData.find((data) => data.id === id));
+    }
+
+    return productsData.filter((data) => data.type === searchType);
+  };
+
+  const filteredData = searchData(searchType);
 
   return (
-    <div>
-      {productsData.slice(0, count).map((data) => (
+    <Wrapper>
+      {filteredData.slice(0, count).map((data) => (
         <ItemCard
           data={data}
           key={data.id}
@@ -14,6 +40,6 @@ export default function ItemCardList ({ count, bookmarks, setBookmarks }) {
           setBookmarks={setBookmarks}
         />
       ))}
-    </div>
-  )
+    </Wrapper>
+  );
 }

--- a/src/constants/itemCardTypes.js
+++ b/src/constants/itemCardTypes.js
@@ -1,6 +1,8 @@
 export const itemCardTypes = {
+  all: 'All',
   product: 'Product',
   category: 'Category',
   exhibition: 'Exhibition',
-  brand: 'Brand'
+  brand: 'Brand',
+  bookmark: 'Bookmark'
 };

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,17 +1,32 @@
 import React from 'react';
+import { styled } from 'styled-components';
+
 import ItemCardList from '../components/ItemCardList';
+import { itemCardTypes } from '../constants/itemCardTypes';
+
+const Title = styled.h1`
+  font-size: 24px;
+  font-weight: 600;
+`;
 
 export default function MainPage ({ bookmarks, setBookmarks }) {
 
   return (
     <main>
-      <h1>상품 리스트</h1>
-        <ItemCardList
-          count={4}
-          bookmarks={bookmarks}
-          setBookmarks={setBookmarks}
-        />
-      <h1>북마크 리스트</h1>
+      <Title>상품 리스트</Title>
+      <ItemCardList
+        count={4}
+        bookmarks={bookmarks}
+        setBookmarks={setBookmarks}
+        searchType={itemCardTypes.all}
+      />
+      <Title>북마크 리스트</Title>
+      <ItemCardList
+        count={4}
+        bookmarks={bookmarks}
+        setBookmarks={setBookmarks}
+        searchType={itemCardTypes.bookmark}
+      />
     </main>
-  )
+  );
 }


### PR DESCRIPTION
## 구현 사항
- **메인 페이지 정렬 및 figma 가이드라인 준수**
  - `MainPage` 및 그 하위 컴포넌트의 css 변경
  - `App` 컴포넌트의 css, jsx 구조 변경 : `MainPage` 및 추후 추가될 페이지 컴포넌트가 브라우저 길이에 상관 없이 중앙에 위치하도록 설정
- **메인 페이지에 북마크 리스트 추가**
  - `ItemCardList` 컴포넌트가 인자로 조건을 받아, 조건(all, product, category, exhibition, brand, bookmark)에 맞는 리스트를 반환하도록 기능 추가
  - `ItemCardList` 컴포넌트가 4개를 초과하는 `itemCard`를 반환할 경우 정렬을 유지하면서 다음 행으로 넘어가도록 css 변경

## [프로젝트 티켓](https://github.com/users/DanoHwang/projects/1?pane=issue&itemId=28003860)
- [x] Header와 Footer를 갖고 있다.
- [x] 해당 메인페이지는 아래와 같은 항목을 가지고 있다.
  - 상품 리스트
  - 북마크 리스트
- [x] 리스트 공통
  - ItemCard 개발 후 해당 상품 리스트 및 북마크 리스트 섹션에 적용해 렌더링 하기
  - 메인 페이지의 리스트 섹션에서 보여지는 상품의 개수는 4개로 제한

## 티켓 추가 사항
- 현재 목업을 이용해 작업하고 있으므로 서버로부터 데이터를 받아오는 부분은 티켓을 추가하여 작업할 예정입니다.

## 스크린샷
![스크린샷 2023-05-16 오후 1 01 57](https://github.com/DanoHwang/fe-sprint-coz-shopping/assets/124581006/11c79738-3f07-4ca2-b3bc-ddd5c9974e01)
