### PR TITLE
Refactor: Header 컴포넌트의 드롭다운 컴포넌트화 및 styled-component를 별도 파일로 분리

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,61 +1,22 @@
 import React from 'react';
-import { styled } from 'styled-components';
 import { Link } from 'react-router-dom';
 
-const Menu = styled.div`
-  width: 200px;
-  height: 150px;
-  border-radius: 12px;
-  box-shadow: 0px 0px 8px 0px #0000001A;
-  background-color: #FFFF;
-  position: absolute;
-  top: 87px;
-  right: 32px;
-`;
-
-const Triangle = styled.div`
-  width: 25px;
-  height: 25px;
-  background-color: #FFFF;
-  box-shadow: -3px 3px 8px -3px #0000001A;
-  transform: rotate(135deg);
-  position: absolute;
-  top: 75px;
-  right: 80px;
-  z-index: 1;
-`;
-
-const MenuItem = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 200px;
-  height: 50px;
-  border-bottom: 0.5px solid #0000001A;
-
-  &:last-child {
-    border-bottom: none;
-  }
-
-  &:hover:not(:first-child) {
-    cursor: pointer;
-  }
-`;
+import * as S from '../styles/DropdownStyle';
 
 export default function Dropdown ({ handleMenuOpen }) {
 
   return (
     <>
-      <Triangle />
-      <Menu>
-        <MenuItem>OOO님, 안녕하세요!</MenuItem>
-        <MenuItem>
+      <S.Triangle />
+      <S.Menu>
+        <S.MenuItem>OOO님, 안녕하세요!</S.MenuItem>
+        <S.MenuItem>
           <Link to='/products/list' onClick={handleMenuOpen}>상품리스트 페이지</Link>
-        </MenuItem>
-        <MenuItem>
+        </S.MenuItem>
+        <S.MenuItem>
           <Link to='/bookmark' onClick={handleMenuOpen}>북마크 페이지</Link>
-        </MenuItem>
-      </Menu>
+        </S.MenuItem>
+      </S.Menu>
     </>
   );
 }

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { styled } from 'styled-components';
+import { Link } from 'react-router-dom';
+
+const Menu = styled.div`
+  width: 200px;
+  height: 150px;
+  border-radius: 12px;
+  box-shadow: 0px 0px 8px 0px #0000001A;
+  background-color: #FFFF;
+  position: absolute;
+  top: 87px;
+  right: 32px;
+`;
+
+const Triangle = styled.div`
+  width: 25px;
+  height: 25px;
+  background-color: #FFFF;
+  box-shadow: -3px 3px 8px -3px #0000001A;
+  transform: rotate(135deg);
+  position: absolute;
+  top: 75px;
+  right: 80px;
+  z-index: 1;
+`;
+
+const MenuItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 50px;
+  border-bottom: 0.5px solid #0000001A;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover:not(:first-child) {
+    cursor: pointer;
+  }
+`;
+
+export default function Dropdown ({ handleMenuOpen }) {
+
+  return (
+    <>
+      <Triangle />
+      <Menu>
+        <MenuItem>OOO님, 안녕하세요!</MenuItem>
+        <MenuItem>
+          <Link to='/products/list' onClick={handleMenuOpen}>상품리스트 페이지</Link>
+        </MenuItem>
+        <MenuItem>
+          <Link to='/bookmark' onClick={handleMenuOpen}>북마크 페이지</Link>
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/pages/Header.js
+++ b/src/pages/Header.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { styled } from 'styled-components';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import logoImg from '../assets/logo.svg';
 import menuImg from '../assets/hamburger-button.svg';
+import Dropdown from '../components/Dropdown';
 
 const Head = styled.header`
   display: flex;
@@ -39,51 +40,11 @@ const HamburgerButton = styled.img`
   cursor: pointer;
 `;
 
-const Menu = styled.div`
-  width: 200px;
-  height: 150px;
-  border-radius: 12px;
-  box-shadow: 0px 0px 8px 0px #0000001A;
-  background-color: #FFFF;
-  position: absolute;
-  top: 87px;
-  right: 32px;
-`;
-
-const Triangle = styled.div`
-  width: 25px;
-  height: 25px;
-  background-color: #FFFF;
-  box-shadow: -3px 3px 8px -3px #0000001A;
-  transform: rotate(135deg);
-  position: absolute;
-  top: 75px;
-  right: 80px;
-  z-index: 1;
-`;
-
-const MenuItem = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 200px;
-  height: 50px;
-  border-bottom: 0.5px solid #0000001A;
-
-  &:last-child {
-    border-bottom: none;
-  }
-
-  &:hover:not(:first-child) {
-    cursor: pointer;
-  }
-`;
-
 export default function Header () {
   const [ isMenuOpened, setIsMenuOpened ] = useState(false);
   const navigate = useNavigate();
 
-  const handleMenuClick = () => {
+  const handleMenuOpen = () => {
     setIsMenuOpened(!isMenuOpened);
   };
 
@@ -97,21 +58,8 @@ export default function Header () {
         <LogoImage src={logoImg} />
         <Title>COZ Shopping</Title>
       </LogoWrapper>
-      <HamburgerButton src={menuImg} onClick={handleMenuClick} />
-      {isMenuOpened && (
-        <>
-          <Triangle />
-          <Menu>
-            <MenuItem>OOO님, 안녕하세요!</MenuItem>
-            <MenuItem>
-              <Link to='/products/list' onClick={handleMenuClick}>상품리스트 페이지</Link>
-            </MenuItem>
-            <MenuItem>
-              <Link to='/bookmark' onClick={handleMenuClick}>북마크 페이지</Link>
-            </MenuItem>
-          </Menu>
-        </>
-      )}
+      <HamburgerButton src={menuImg} onClick={handleMenuOpen} />
+      {isMenuOpened && <Dropdown handleMenuOpen={handleMenuOpen} />}
     </Head>
   );
 }

--- a/src/pages/Header.js
+++ b/src/pages/Header.js
@@ -1,44 +1,11 @@
 import React, { useState } from 'react';
-import { styled } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
 import logoImg from '../assets/logo.svg';
 import menuImg from '../assets/hamburger-button.svg';
 import Dropdown from '../components/Dropdown';
 
-const Head = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  box-shadow: 0px 8px 8px rgba(0, 0, 0, 0.1);
-  position: sticky;
-`;
-
-const LogoWrapper = styled.div`
-  margin: 25px 0;
-  cursor: pointer;
-`;
-
-const LogoImage = styled.img`
-  width: 55px;
-  height: 30px;
-  margin-left: 76px;
-`;
-
-const Title = styled.div`
-  display: inline-block;
-  margin-left: 12px;
-  font-weight: 700;
-  font-size: 32px;
-`;
-
-const HamburgerButton = styled.img`
-  width: 34px;
-  height: 24px;
-  margin-right: 76px;
-  position: relative;
-  cursor: pointer;
-`;
+import * as S from '../styles/HeaderStyle';
 
 export default function Header () {
   const [ isMenuOpened, setIsMenuOpened ] = useState(false);
@@ -53,13 +20,13 @@ export default function Header () {
   };
 
   return (
-    <Head>
-      <LogoWrapper onClick={handleLogoClick}>
-        <LogoImage src={logoImg} />
-        <Title>COZ Shopping</Title>
-      </LogoWrapper>
-      <HamburgerButton src={menuImg} onClick={handleMenuOpen} />
+    <S.Head>
+      <S.LogoWrapper onClick={handleLogoClick}>
+        <S.LogoImage src={logoImg} />
+        <S.Title>COZ Shopping</S.Title>
+      </S.LogoWrapper>
+      <S.HamburgerButton src={menuImg} onClick={handleMenuOpen} />
       {isMenuOpened && <Dropdown handleMenuOpen={handleMenuOpen} />}
-    </Head>
+    </S.Head>
   );
 }

--- a/src/styles/DropdownStyle.js
+++ b/src/styles/DropdownStyle.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+export const Menu = styled.div`
+  position: absolute;
+  top: 87px;
+  right: 32px;
+  width: 200px;
+  height: 150px;
+  box-shadow: 0px 0px 8px 0px #0000001A;
+  border-radius: 12px;
+  background-color: #FFFF;
+`;
+
+export const Triangle = styled.div`
+  position: absolute;
+  top: 75px;
+  right: 80px;
+  z-index: 1;
+  width: 25px;
+  height: 25px;
+  box-shadow: -3px 3px 8px -3px #0000001A;
+  background-color: #FFFF;
+  transform: rotate(135deg);
+`;
+
+export const MenuItem = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 200px;
+  height: 50px;
+  border-bottom: 0.5px solid #0000001A;
+  background-color: #FFFF;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover:not(:first-child) {
+    cursor: pointer;
+  }
+`;

--- a/src/styles/HeaderStyle.js
+++ b/src/styles/HeaderStyle.js
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const Head = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0px 8px 8px rgba(0, 0, 0, 0.1);
+  position: sticky;
+`;
+
+export const LogoWrapper = styled.div`
+  margin: 25px 0;
+  cursor: pointer;
+`;
+
+export const LogoImage = styled.img`
+  width: 55px;
+  height: 30px;
+  margin-left: 76px;
+`;
+
+export const Title = styled.div`
+  display: inline-block;
+  margin-left: 12px;
+  font-weight: 700;
+  font-size: 32px;
+`;
+
+export const HamburgerButton = styled.img`
+  position: relative;
+  width: 34px;
+  height: 24px;
+  margin-right: 76px;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## 변경 사항
1차 코드 리뷰를 반영하여 아래와 같은 사항을 변경했습니다.
- **Header 컴포넌트**
  - 드롭다운이 `Dropdown` 컴포넌트로 분리되었습니다.
- **Header, Dropdown 컴포넌트의 styled 설정을 별도의 파일로 분리**
  - src/styles 폴더에 컴포넌트별 파일을 생성하였습니다.
  - 다른 컴포넌트의 styled 설정은 2차 코드 리뷰가 완료된 후 일괄적으로 분리할 예정입니다.

## 궁금한 점
- 햄버거 버튼 및 드롭다운 내부 메뉴(상품페이지, 북마크 페이지)버튼을 클릭할 때, `isMenuOpened` 상태를 변경하는 `handleMenuOpen`이라는 함수가 있습니다. 리뷰어님이 생각하실 때 이 함수명이 적절한지, 그렇지 않다면 어떤 식으로 바꾸는 것이 적절한지 궁금합니다. 감사합니다!
