### PR TITLE
Feat: 상품리스트 페이지 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import './App.css';
 import MainPage from './pages/MainPage';
 import Footer from './pages/Footer';
 import Header from './pages/Header';
+import ProductListPage from './pages/ProductListPage';
 
 const Wrapper = styled.div`
   display: flex;
@@ -29,6 +30,7 @@ function App() {
       <Wrapper>
         <Routes>
           <Route path='/' element={<MainPage bookmarks={bookmarks} setBookmarks={setBookmarks} />} />
+          <Route path='/products/list' element={<ProductListPage />} />
         </Routes>
       </Wrapper>
       <Footer />

--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -6,17 +6,18 @@ const Wrapper = styled.div`
   height: 110px;
   margin-bottom: 12px;
   text-align: center;
+  cursor: pointer;
 `;
 
 const Title = styled.h2`
   padding: 2.5px 0;
   margin-top: 4px;
-  color: ${props => props.isChecked ? '#412DD4' : '#000'};
-  font-weight: ${props => props.isChecked && '700'};
-  text-decoration: ${props => props.isChecked && 'underline'};
+  color: ${props => props.$isChecked ? '#412DD4' : '#000'};
+  font-weight: ${props => props.$isChecked && '700'};
+  text-decoration: ${props => props.$isChecked && 'underline'};
 `;
 
-export default function Filter ({ image, type, setCheckedFilter, isChecked }) {
+export default function Filter ({ type, name, image, setCheckedFilter, checkedFilter }) {
   const handleClick = () => {
     setCheckedFilter(type);
   };
@@ -24,7 +25,7 @@ export default function Filter ({ image, type, setCheckedFilter, isChecked }) {
   return (
     <Wrapper onClick={handleClick}>
       <img src={image} alt='' />
-      <Title isChecked={isChecked}>{type}</Title>
+      <Title $isChecked={checkedFilter === type}>{name}</Title>
     </Wrapper>
   );
 }

--- a/src/components/FilterList.js
+++ b/src/components/FilterList.js
@@ -6,16 +6,17 @@ import productImg from '../assets/filter-product.svg';
 import categoryImg from '../assets/filter-category.svg';
 import exhibitionImg from '../assets/filter-exhibition.svg';
 import brandImg from '../assets/filter-brand.svg';
-import { filterTypes } from '../constants/filterTypes';
 
 import Filter from './Filter';
+import { filterTypes } from '../constants/filterTypes';
+import { itemCardTypes } from '../constants/itemCardTypes';
 
 const filters = [
-  { type: filterTypes.all, image: allImg },
-  { type: filterTypes.product, image: productImg },
-  { type: filterTypes.category, image: categoryImg },
-  { type: filterTypes.exhibition, image: exhibitionImg },
-  { type: filterTypes.brand, image: brandImg }
+  { name: filterTypes.all, image: allImg, type: itemCardTypes.all },
+  { name: filterTypes.product, image: productImg, type: itemCardTypes.product },
+  { name: filterTypes.category, image: categoryImg, type: itemCardTypes.category },
+  { name: filterTypes.exhibition, image: exhibitionImg, type: itemCardTypes.exhibition },
+  { name: filterTypes.brand, image: brandImg, type: itemCardTypes.brand }
 ];
 
 const Wrapper = styled.div`
@@ -26,16 +27,17 @@ const Wrapper = styled.div`
   text-align: center;
 `;
 
-export default function FilterList ({ setCheckedFilter, isChecked = true }) {
+export default function FilterList ({ setCheckedFilter, checkedFilter }) {
 
   return (
     <Wrapper>
-      {filters.map(({ type, image }) => (
+      {filters.map(({ type, name, image }) => (
         <Filter
           type={type}
+          name={name}
           image={image}
           setCheckedFilter={setCheckedFilter}
-          isChecked={isChecked}
+          checkedFilter={checkedFilter}
           key={type}
         />
       ))}

--- a/src/pages/ProductListPage.js
+++ b/src/pages/ProductListPage.js
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { styled } from 'styled-components';
+
+import FilterList from '../components/FilterList';
+import ItemCardList from '../components/ItemCardList';
+import { itemCardTypes } from '../constants/itemCardTypes';
+
+const Wrapper = styled.main`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default function ProductListPage () {
+  const [ checkedFilter, setCheckedFilter ] = useState(itemCardTypes.all);
+
+  // refactor/data-type 브랜치 머지 후 아래 Line22-24 수정 예정
+  const [ bookmarks, setBookmarks ] = useState(
+    JSON.parse(window.localStorage.getItem('bookmarks')) || []
+  );
+
+  return (
+    <Wrapper>
+      <FilterList setCheckedFilter={setCheckedFilter} checkedFilter={checkedFilter} />
+      <ItemCardList
+        count={10}
+        bookmarks={bookmarks}
+        setBookmarks={setBookmarks}
+        searchType={checkedFilter}
+      />
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## 구현 사항
- **상품리스트 페이지 생성**
  - 햄버거 버튼을 클릭하면 상품리스트 페이지로 이동합니다.
  - 필터를 클릭하면 알맞은 상품리스트가 렌더됩니다.

## [프로젝트 티켓](https://github.com/users/DanoHwang/projects/1/views/1?pane=issue&itemId=28005046)
- [ ] 서버에서 제공하는 상품 리스트들을 확인할 수 있는 페이지이며 무한 스크롤을 통해 상품들을 계속 보여줄 수 있어야 한다. -> 현재 목업을 사용하고 있으며, 추후 서버에서 데이터를 받아오도록 변경할 예정입니다.
- [x] 상품은 각 상품별로 타입이 존재한다. (상품, 카테고리, 기획전, 브랜드)
- [x] 상단의 필터 버튼을 통해 상품을 타입별로 조회해 보여줄 수 있어야 한다.
- [x] 각 상품에 존재하는 북마크 버튼을 눌러 원하는 상품을 북마크 할 수 있어야 한다.
- [x] 이미 북마크 된 상품의 경우, 북마크 버튼에 표시를 해주어야 하며 다시 한 번 북마크 버튼을 클릭 시 해당 상품을 북마크에서 삭제한다.

## 스크린샷
https://github.com/DanoHwang/fe-sprint-coz-shopping/assets/124581006/b462e617-37da-4c24-a7d8-fc8b3fb4b1fb
