### PR TITLE
Feat: 북마크 페이지 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import MainPage from './pages/MainPage';
 import Footer from './pages/Footer';
 import Header from './pages/Header';
 import ProductListPage from './pages/ProductListPage';
+import BookmarkPage from './pages/BookmarkPage';
 
 const Wrapper = styled.div`
   display: flex;
@@ -27,6 +28,7 @@ function App() {
         <Routes>
           <Route path='/' element={<MainPage />} />
           <Route path='/products/list' element={<ProductListPage />} />
+          <Route path='/bookmark' element={<BookmarkPage />} />
         </Routes>
       </Wrapper>
       <Footer />

--- a/src/components/ItemCard.js
+++ b/src/components/ItemCard.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { itemCardTypes } from '../constants/itemCardTypes';
-import { updateLocalStorage } from '../utils/updateLocalStorage';
+import { manageLocalStorage } from '../utils/manageLocalStorage';
 import * as S from '../styles/ItemCardStyle';
 
 export default function ItemCard ({ data, bookmarks, setBookmarks }) {
   const { product, exhibition, brand } = itemCardTypes;
-  const { addBookmark, deleteBookmark } = updateLocalStorage;
+  const { addBookmark, deleteBookmark } = manageLocalStorage;
   const isBookmarked = bookmarks.has(data.id) ? true : false;
 
   const handleBookmark = () => {

--- a/src/pages/BookmarkPage.js
+++ b/src/pages/BookmarkPage.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+
+import { itemCardTypes } from '../constants/itemCardTypes';
+import * as S from '../styles/BookmarkPageStyle';
+
+import FilterList from '../components/FilterList';
+import ItemCardList from '../components/ItemCardList';
+
+export default function BookmarkPage () {
+  const [ checkedFilter, setCheckedFilter ] = useState(itemCardTypes.all);
+
+  const [ bookmarks, setBookmarks ] = useState(
+    new Map(JSON.parse(window.localStorage.getItem('bookmarks'))) || new Map()
+  );
+
+  return (
+    <S.Wrapper>
+      <FilterList setCheckedFilter={setCheckedFilter} checkedFilter={checkedFilter} />
+      <ItemCardList
+        count={10}
+        bookmarks={bookmarks}
+        setBookmarks={setBookmarks}
+        searchType={checkedFilter}
+        isBookmarkList={true}
+      />
+    </S.Wrapper>
+  )
+}

--- a/src/pages/BookmarkPage.js
+++ b/src/pages/BookmarkPage.js
@@ -5,12 +5,13 @@ import * as S from '../styles/BookmarkPageStyle';
 
 import FilterList from '../components/FilterList';
 import ItemCardList from '../components/ItemCardList';
+import { manageLocalStorage } from '../utils/manageLocalStorage';
 
 export default function BookmarkPage () {
   const [ checkedFilter, setCheckedFilter ] = useState(itemCardTypes.all);
 
   const [ bookmarks, setBookmarks ] = useState(
-    new Map(JSON.parse(window.localStorage.getItem('bookmarks'))) || new Map()
+    manageLocalStorage.getBookmarks()
   );
 
   return (

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -4,10 +4,11 @@ import { itemCardTypes } from '../constants/itemCardTypes';
 import * as S from '../styles/MainPageStyle';
 
 import ItemCardList from '../components/ItemCardList';
+import { manageLocalStorage } from '../utils/manageLocalStorage';
 
 export default function MainPage () {
   const [ bookmarks, setBookmarks ] = useState(
-    new Map(JSON.parse(window.localStorage.getItem('bookmarks'))) || new Map()
+    manageLocalStorage.getBookmarks()
   );
 
   return (

--- a/src/pages/ProductListPage.js
+++ b/src/pages/ProductListPage.js
@@ -5,12 +5,13 @@ import * as S from '../styles/ProductListPageStyle';
 
 import FilterList from '../components/FilterList';
 import ItemCardList from '../components/ItemCardList';
+import { manageLocalStorage } from '../utils/manageLocalStorage';
 
 export default function ProductListPage () {
   const [ checkedFilter, setCheckedFilter ] = useState(itemCardTypes.all);
 
   const [ bookmarks, setBookmarks ] = useState(
-    new Map(JSON.parse(window.localStorage.getItem('bookmarks'))) || new Map()
+    manageLocalStorage.getBookmarks()
   );
 
   return (

--- a/src/styles/BookmarkPageStyle.js
+++ b/src/styles/BookmarkPageStyle.js
@@ -1,0 +1,8 @@
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.main`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/utils/manageLocalStorage.js
+++ b/src/utils/manageLocalStorage.js
@@ -1,4 +1,4 @@
-export const updateLocalStorage = {
+export const manageLocalStorage = {
   addBookmark: (setter, key, value) => {
     setter((prev) => {
       const newState = new Map([...prev, [key, value]]);
@@ -20,5 +20,9 @@ export const updateLocalStorage = {
 
       return newState;
     });
+  },
+
+  getBookmarks: () => {
+    return new Map(JSON.parse(window.localStorage.getItem('bookmarks'))) || new Map()
   }
 };


### PR DESCRIPTION
## 구현 사항
- **북마크 페이지 생성**
  - 햄버거 버튼을 클릭하면 북마크 페이지로 이동합니다.
  - 필터를 클릭하면 필터링된 북마크 상품 목록이 렌더됩니다.

## [프로젝트 티켓](https://github.com/users/DanoHwang/projects/1/views/1?pane=issue&itemId=28005512)
- [ ] 서버에서 제공하는 상품 리스트들을 확인할 수 있는 페이지이며 무한 스크롤을 통해 상품들을 계속 보여줄 수 있어야 한다. -> 현재 목업을 사용하고 있으며, 추후 서버에서 데이터를 받아오도록 변경할 예정입니다.
- [x] 상품은 각 상품별로 타입이 존재한다. (상품, 카테고리, 기획전, 브랜드)
- [x] 상단의 필터 버튼을 통해 상품을 타입별로 조회해 보여줄 수 있어야 한다.
- [x] 각 상품에 존재하는 북마크 버튼을 눌러 원하는 상품을 북마크 할 수 있어야 한다.
- [x] 이미 북마크 된 상품의 경우, 북마크 버튼에 표시를 해주어야 하며 다시 한 번 북마크 버튼을 클릭 시 해당 상품을 북마크에서 삭제한다.

## 스크린샷
https://github.com/DanoHwang/fe-sprint-coz-shopping/assets/124581006/f7bc2fbb-132f-471e-9d45-f2292cbb4695

